### PR TITLE
Nicht funktionierendes Frontend logging gefixed

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11393,11 +11393,6 @@
         }
       }
     },
-    "vue-observe-visibility": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
-      "integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
-    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/frontend/src/Error.vue
+++ b/frontend/src/Error.vue
@@ -18,6 +18,8 @@
 </template>
 
 <script>
+import axios from 'axios';
+
 export default {
 	name: 'Error',
 	props: {
@@ -49,6 +51,12 @@ export default {
 				error.stack = this.errorData.error;
 				error.component = `${this.errorData.source}, Zeile: ${this.errorData.lineno}`;
 			}
+
+			axios.post(
+				`${process.env.VUE_APP_BACKENDPATH}log/frontend/`,
+				error,
+			);
+
 			return error;
 		},
 	},


### PR DESCRIPTION
Die error.vue wurde so erweitert, dass immer wenn diese Fehler Seite aufgerufen wird, der entsprechende Fehler im `frontendError.log` File abgelegt wird. Zum testen einfach das Backend ohne `paintings.json`, `archivals.json`, `graphics.json` oder `events.json` starten und dann das Frontend starten.